### PR TITLE
Use next version when deploying Test Flight

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -13,6 +13,8 @@ jobs:
         uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
       - name: Setup Fastlane
         run: bundle install
+      - name: Bump beta version
+        run: bumpver update --no-commit
       - name: Deploy Beta to Test Flight
         env:
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ secrets:
 
 deps:
 	bundle install
-	pip3 install bumpver==2023.1124
+	pip3 install bumpver==2023.1125
 
 .PHONY: bump-version
 bump-version:


### PR DESCRIPTION
Fixes a CI issue ([sample job](https://github.com/gvsucis/art-at-gvsu-ios/actions/runs/5708700651/job/15466619793)) where deploying to Test Flight fails due to a closed release train. This change ensures that the next version - in this case 2023.07.1009 - is used instead of the current closed version.