### PR TITLE
Add artist row indicator

### DIFF
--- a/ArtAtGVSU/Views/Artworks/ArtworkDetailView.swift
+++ b/ArtAtGVSU/Views/Artworks/ArtworkDetailView.swift
@@ -79,7 +79,11 @@ struct ArtworkDetailContent: View {
             ForEach(nonEmptyTextRows(artwork), id: \.title ) { row in
                 if row.isArtistName {
                     NavigationLink(destination: ArtistDetailView(id: artwork.artistID)) {
-                        DetailTextRow(title: row.title, description: row.description)
+                        DetailTextRow(
+                            title: row.title,
+                            description: row.description,
+                            showIndicator: true
+                        )
                     }
                 } else {
                     DetailTextRow(title: row.title, description: row.description)
@@ -229,4 +233,3 @@ struct ArtworkDetail_Previews: PreviewProvider {
         func presentArtworkDetail(artworkID: String) {}
     }
 }
-

--- a/ArtAtGVSU/Views/DetailTextRow.swift
+++ b/ArtAtGVSU/Views/DetailTextRow.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct DetailTextRow: View {
     let title: String
     let description: String
+    var showIndicator: Bool = false
 
     var body: some View {
         HStack {
@@ -19,10 +20,15 @@ struct DetailTextRow: View {
                     .font(.title3)
                     .foregroundColor(Color(UIColor.secondaryLabel))
                 Text(description)
+                    .multilineTextAlignment(.leading)
                     .fixedSize(horizontal: false, vertical: true)
                     .foregroundColor(Color(UIColor.label))
             }
             Spacer()
+            if showIndicator {
+                Image(systemName: "chevron.right")
+                    .foregroundColor(Color(UIColor.label))
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes multiline text alignment and adds a chevron indicator to the artist row.

<img src="https://github.com/user-attachments/assets/5130a4ca-460d-4f3d-9ffc-7e4289839c3a" width="400px">

Closes #24 
